### PR TITLE
Reduce peak memory usage of WSPR decoder

### DIFF
--- a/wsprd.c
+++ b/wsprd.c
@@ -142,8 +142,8 @@ unsigned long readwavfile(char *ptr_to_infile, int ntrmin, float *idat, float *q
     fread(buf2,2,npoints,fp); //Read raw data
     fclose(fp);
 
-    realin=pffft_aligned_malloc(sizeof(float)*nfft1);
-    fftout=pffft_aligned_malloc(sizeof(float)*2*(nfft1/2+1));
+    realin=pffft_aligned_malloc(sizeof(float)*2*(nfft1/2+1));
+    fftout=realin;
     fftsetup1=pffft_new_setup(nfft1, PFFFT_REAL);
 
     for (i=0; i<npoints; i++) {
@@ -155,8 +155,7 @@ unsigned long readwavfile(char *ptr_to_infile, int ntrmin, float *idat, float *q
     }
     free(buf2);
 
-    pffft_transform_ordered(fftsetup1, realin, fftout, NULL, PFFFT_FORWARD);
-    pffft_aligned_free(realin);
+    pffft_transform_ordered(fftsetup1, realin, realin, NULL, PFFFT_FORWARD);
 
     fftin=pffft_aligned_malloc(sizeof(float)*2*nfft2);
 
@@ -1482,6 +1481,8 @@ int main(int argc, char *argv[])
     }
 
     free(hashtab);
+    free(cw);
+    free(apmask);
     free(symbols);
     free(decdata);
     free(channel_symbols);


### PR DESCRIPTION
This reduces the peak memory consumption from ~21MB to around ~15MB by reusing the `realin` buffer.

Before this PR (Click screenshot to zoom in):

![Screenshot_2023-02-04_16-03-56](https://user-images.githubusercontent.com/79528/216762241-10394d80-598b-493a-a54a-3d1fa9f9985a.png)

After this PR:

![Screenshot_2023-02-04_16-03-05](https://user-images.githubusercontent.com/79528/216762252-d1aabef3-2e10-4521-9a76-c63e1667f39b.png)

Memory correctness for my change was checked using ASan using the following change:

```
diff --git a/Makefile b/Makefile
index c4595ea..432e078 100644
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ FC = gfortran
 LD = gfortran
 RM = rm -f
 
-CFLAGS = -Wall -O3 -funroll-loops -ffast-math -fsingle-precision-constant
-FFLAGS = -Wall -O3 -funroll-loops -ffast-math -fsingle-precision-constant
+CFLAGS = -Wall -O3 -funroll-loops -ffast-math -fsingle-precision-constant -fsanitize=address -g
+FFLAGS = -Wall -O3 -funroll-loops -ffast-math -fsingle-precision-constant -fsanitize=address -g
 
 all: $(TARGET)
 
@@ -20,7 +20,7 @@ all: $(TARGET)
        ${FC} -c ${FFLAGS} $< -o $@
 
 $(TARGET): $(OBJECTS)
-       $(LD) $(OBJECTS) -o $@
+       $(LD) -fsanitize=address $(OBJECTS) -o $@
 
 clean:
        $(RM) *.o $(TARGET)
```

```
$ make; ./wsprd ~/Downloads/150426_0918.wav     
make: Nothing to be done for 'all'.
0918  -9  1.1   0.001446  0  ND6P DM04 30 
0918 -15  0.1   0.001460  0  W5BIT EL09 17 
0918 -24  2.2   0.001465  0  G8VDQ IO91 37 
0918  -6  0.7   0.001489  0  WD4LHT EL89 30 
0918  -1 -0.8   0.001503  0  NM7J DM26 30 
0918 -21  0.5   0.001517  0  KI7CI DM09 37 
0918 -18 -2.0   0.001530  0  DJ6OL JO52 37 
0918 -11  0.8   0.001587  0  W3HH EL89 30 
0918 -25  0.7   0.001594  0  W3BI FN20 30 
<DecodeFinished>
```

I would like to reduce the peak memory consumption of `wsprd` further so that it can be run on a microcontroller which has a 8MB PSRAM chip attached. Any help would be awesome - thank you!
